### PR TITLE
Fixed failing build on Windows and certain Linux systems

### DIFF
--- a/library/Zippy/ZipArchive.hpp
+++ b/library/Zippy/ZipArchive.hpp
@@ -39,6 +39,10 @@
 
 #ifdef _WIN32
 #include <direct.h>
+#else
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #endif
 
 // ===== Other Includes

--- a/library/Zippy/ZipArchive.hpp
+++ b/library/Zippy/ZipArchive.hpp
@@ -37,6 +37,10 @@
 #include <memory>
 #include <fstream>
 
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
 // ===== Other Includes
 #include "miniz/miniz.h"
 #include "ZipException.hpp"


### PR DESCRIPTION
The build was failing due to missing include